### PR TITLE
Add multitask_server: serve one task of a multi-task checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ pip install flash-attn --no-build-isolation
 | Model | Contents | Link |
 |---|---|---|
 | $N_0$-TWAM pretrained | `transformer/` `vae/` `text_encoder/` `tokenizer/` + `norm_stat_pretrain.json` + `empty_emb.pt` | [NeoteAI/n0-twam-base](https://huggingface.co/NeoteAI/n0-twam-base) |
+| Post-trained · UniVTAC 8 tasks · absEE | `transformer/` + `train_meta.json` | [NeoteAI/n0-twam-univtac-absee](https://huggingface.co/NeoteAI/n0-twam-univtac-absee) |
+| Post-trained · UniVTAC 8 tasks · delta EE | `transformer/` + `train_meta.json` | [NeoteAI/n0-twam-univtac-delta](https://huggingface.co/NeoteAI/n0-twam-univtac-delta) |
+| Post-trained · NeoSim 12 tasks · absEE | `transformer/` + `train_meta.json` | [NeoteAI/n0-twam-neosim-absee](https://huggingface.co/NeoteAI/n0-twam-neosim-absee) |
+| Post-trained · NeoSim 12 tasks · delta EE | `transformer/` + `train_meta.json` | [NeoteAI/n0-twam-neosim-delta](https://huggingface.co/NeoteAI/n0-twam-neosim-delta) |
+
+The post-trained checkpoints are **multi-task** models, post-trained from
+[n0-twam-base](https://huggingface.co/NeoteAI/n0-twam-base) with this toolkit's
+recipe ([POST_TRAINING.md](docs/POST_TRAINING.md)): *UniVTAC 8* = the 8
+single-arm tasks inherited from UniVTAC, *NeoSim 12* = the 12 NeoSim benchmark
+tasks (4 single-arm + 8 dual-arm); *absEE* = absolute end-effector actions,
+*delta EE* = horizon-delta actions; all trained on marker-less `rgb` tactile.
+Each task trains with its own normalization stats, so serve them with the
+`multitask_server` config, which selects the task and wires its stats, keys and
+prompt — see [DEPLOY.md](docs/DEPLOY.md#serving-a-multi-task-checkpoint).
 
 ```python
 from huggingface_hub import snapshot_download

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -31,6 +31,31 @@ At startup the server cross-checks the config against the checkpoint's
 **refuses to start** on a mismatch or on placeholder norm stats — fix the
 config rather than bypassing the check.
 
+### Serving a multi-task checkpoint
+
+A multi-task pool trains every task with its **own** normalization stats (the
+`<norm>_per_robot.json` table from `script/build_task_pool.py`) — there is no
+single serve norm, and de-normalizing with the pool-level file (a training-only
+fallback envelope) scales actions wrongly. For these checkpoints — including
+the released `NeoteAI/n0-twam-univtac-{absee,delta}` and
+`NeoteAI/n0-twam-neosim-{absee,delta}` — use `multitask_server`
+(`n0_twam/configs/twam_multitask_server_cfg.py`): it selects one task and
+wires the stats, camera/tactile keys, action channels and prompt that task
+trained with, all read from the pool itself.
+
+```bash
+TWAM_SERVE_POOL=/path/to/pools/my_tasks TWAM_SERVE_TASK=my_task \
+TWAM_SERVE_ACTION_MODE=absee TWAM_SERVE_BUNDLE=/path/to/serve-bundle \
+TWAM_SERVE_OUT=/path/to/serve-output \
+  python -m n0_twam.n0_twam_server --config-name multitask_server --port 29601
+```
+
+One server instance serves one task — run several instances (different
+`TWAM_SERVE_TASK` / `--port`) to evaluate several tasks in parallel. The
+startup cross-check adapts accordingly: the live norm is verified against the
+pool's per-task table, and the served task's action channels must be a subset
+of the training union recorded in `train_meta.json`.
+
 For the released pretrain checkpoint use `twam_server`
 (`n0_twam/configs/twam_server_cfg.py`):
 

--- a/docs/POST_TRAINING.md
+++ b/docs/POST_TRAINING.md
@@ -82,7 +82,7 @@ Edit the `EDIT ME` block of
 
 Two switches live in the same block:
 
-- `_ACTION_MODE` — `"absee"` (default) or `"pi05_delta"`; must match the
+- `_ACTION_MODE` — `"absee"` (default) or `"delta"` (delta EE); must match the
   `--mode` you used in step 3.
 - **Ablation switches**, default = full model: `_USE_LOCAL_TACTILE = False`
   knocks out the local (observed) stream; `_TACTILE_GLOBAL_ZERO = True` knocks
@@ -104,6 +104,24 @@ zero-init on top of the local-off pretrain checkpoint) and adapts them to your
 data. Checkpoints land under `<save_root>/checkpoints/checkpoint_step_*/`, each
 with a `train_meta.json` snapshot of the serve-critical settings — the inference
 server cross-checks it at startup and refuses to serve a mismatched config.
+
+## Released post-trained checkpoints
+
+Four ready-made post-trained models (post-trained from
+[n0-twam-base](https://huggingface.co/NeoteAI/n0-twam-base) with this exact
+recipe, 10000 steps, marker-less `rgb` tactile) are on the Hub — serve them
+directly, or use them as baselines for your own runs:
+
+| Task pool | absEE | delta EE |
+|---|---|---|
+| UniVTAC 8 single-arm tasks | [n0-twam-univtac-absee](https://huggingface.co/NeoteAI/n0-twam-univtac-absee) | [n0-twam-univtac-delta](https://huggingface.co/NeoteAI/n0-twam-univtac-delta) |
+| NeoSim 12 tasks (4 single-arm + 8 dual-arm) | [n0-twam-neosim-absee](https://huggingface.co/NeoteAI/n0-twam-neosim-absee) | [n0-twam-neosim-delta](https://huggingface.co/NeoteAI/n0-twam-neosim-delta) |
+
+These are **multi-task** checkpoints: every task trains with its own
+normalization stats (the `per_robot` table from step 3), so serve them with the
+`multitask_server` config, which selects a task and wires its stats, keys and
+prompt — see
+[DEPLOY.md — Serving a multi-task checkpoint](DEPLOY.md#serving-a-multi-task-checkpoint).
 
 ## 6. Deploy and evaluate closed-loop
 

--- a/n0_twam/configs/__init__.py
+++ b/n0_twam/configs/__init__.py
@@ -4,6 +4,7 @@ from .twam_i2va import twam_i2va_cfg
 from .twam_server_cfg import twam_server_cfg
 from .twam_posttrain_cfg import twam_posttrain_cfg
 from .twam_posttrain_server_cfg import twam_posttrain_server_cfg
+from .twam_multitask_server_cfg import twam_multitask_server_cfg
 
 TWAM_CONFIGS = {
     "base": twam_base_cfg,
@@ -11,4 +12,5 @@ TWAM_CONFIGS = {
     "twam_server": twam_server_cfg,
     "posttrain": twam_posttrain_cfg,
     "posttrain_server": twam_posttrain_server_cfg,
+    "multitask_server": twam_multitask_server_cfg,
 }

--- a/n0_twam/configs/twam_multitask_server_cfg.py
+++ b/n0_twam/configs/twam_multitask_server_cfg.py
@@ -1,0 +1,113 @@
+# Copyright 2025-2026 NeoteAI Team. All rights reserved.
+"""Serve ONE task of a multi-task checkpoint (registered "multitask_server").
+
+A multi-task pool trains every task with its OWN normalization stats (the
+``<norm>_per_robot.json`` table build_task_pool.py writes, one entry per repo).
+The checkpoint therefore has no single serve norm: de-normalizing with the
+pool-level file (an envelope kept only as an unreachable training fallback)
+scales actions wrongly, and the train_meta.json snapshot stores that same
+envelope — so a mismatch would even pass the naive cross-check. This config
+selects a task and wires up everything that task trained with:
+
+  * q01/q99 from the pool's ``<norm>_per_robot.json`` entry,
+  * camera / tactile keys from the task repo's ``meta/info.json``
+    (declaration order — the order the task trained with),
+  * action channels from the repo's action dim (10 = single-arm half of the
+    20-d schema, 20 = dual-arm),
+  * the warm-up prompt from the repo's ``meta/tasks.jsonl`` (training text,
+    verbatim; a client reset with a prompt overrides it).
+
+Everything else (recipe, ablation switches, inference knobs) inherits from
+``posttrain_server`` unchanged. The server recognises ``serve_task`` and
+cross-checks the live norm against the per-task table instead of the envelope.
+
+One server instance serves ONE task; run several instances for several tasks:
+
+    TWAM_SERVE_POOL=/path/to/pools/my_tasks TWAM_SERVE_TASK=my_task \\
+      python -m n0_twam.n0_twam_server --config-name multitask_server --port 29601
+"""
+import json
+import os
+from pathlib import Path
+
+from easydict import EasyDict
+
+from .twam_posttrain_server_cfg import twam_posttrain_server_cfg
+
+# ───────── EDIT ME (each value can also be set via the env var) ─────────
+_POOL = Path(os.environ.get("TWAM_SERVE_POOL", "/path/to/pools/my_tasks"))
+_TASK = os.environ.get("TWAM_SERVE_TASK", "my_task")   # repo name under <pool>/train/
+_ACTION_MODE = os.environ.get("TWAM_SERVE_ACTION_MODE", "absee")  # "absee" | "delta"
+_BUNDLE = os.environ.get("TWAM_SERVE_BUNDLE", "/path/to/serve-bundle")
+_SAVE_ROOT = os.environ.get("TWAM_SERVE_OUT", "/path/to/serve-output")
+# ───────── end EDIT ME ─────────
+
+assert _ACTION_MODE in ("absee", "delta"), _ACTION_MODE
+_NORM_NAME = "norm_stat_absee" if _ACTION_MODE == "absee" else "norm_stat"
+
+s = EasyDict()
+s.update(twam_posttrain_server_cfg)
+s.__name__ = f"Config: N0-TWAM multi-task SERVER ({_ACTION_MODE}, task={_TASK})"
+
+s.wan22_pretrained_model_name_or_path = _BUNDLE
+s.save_root = _SAVE_ROOT
+s.action_delta_mode = "none" if _ACTION_MODE == "absee" else "pi05_delta"
+
+# multi-task markers — the server's consistency check keys off serve_task.
+s.serve_task = _TASK
+s.multitask_norm_path = str(_POOL / f"{_NORM_NAME}_per_robot.json")
+
+_repo_meta = _POOL / "train" / _TASK / "meta"
+_per_path = Path(s.multitask_norm_path)
+
+if _POOL.is_dir():
+    # ── per-task norm: the exact stats this task trained with ──
+    assert _per_path.is_file(), (
+        f"multi-task pool {_POOL} has no {_per_path.name} — per-task stats are "
+        "required; the pool-level file is a training-only fallback (see "
+        "script/build_task_pool.py)")
+    _per = json.loads(_per_path.read_text())
+    assert _TASK in _per, (
+        f"task {_TASK!r} not in {_per_path.name} — available: {sorted(_per)}")
+    s.norm_stat = {"q01": list(_per[_TASK]["q01"]), "q99": list(_per[_TASK]["q99"])}
+    s.norm_stat_path = f"{_per_path}[{_TASK}]"
+
+    # ── observation contract + prompt, from the task repo itself ──
+    _info = json.loads((_repo_meta / "info.json").read_text())
+    _video_keys = [k for k, v in _info["features"].items()
+                   if k.startswith("observation.images.") and v.get("dtype") == "video"]
+    s.obs_cam_keys = [k for k in _video_keys if "tactile" not in k]
+    s.tactile_keys = [k for k in _video_keys if "tactile" in k]
+    s.tactile_sensor_id_map = {k: i for i, k in enumerate(s.tactile_keys)}
+
+    _action_dim = int(_info["features"]["action"]["shape"][0])
+    s.used_action_channel_ids = list(range(min(_action_dim, s.action_dim)))
+    _inverse = [len(s.used_action_channel_ids)] * s.action_dim
+    for _i, _j in enumerate(s.used_action_channel_ids):
+        _inverse[_j] = _i
+    s.inverse_used_action_channel_ids = _inverse
+
+    _task_row = json.loads(
+        (_repo_meta / "tasks.jsonl").read_text().splitlines()[0])
+    s.prompt = _task_row["task"]
+    s.eval_prompt = s.prompt
+else:  # keep import safe pre-data-prep; runtime guards refuse the placeholder
+    s.norm_stat = {"q01": [-1.0] * 20, "q99": [1.0] * 20}
+    s.norm_stat_path = str(_per_path) + " (POOL MISSING)"
+
+# ── self-check ──
+assert s.action_delta_mode in ("none", "pi05_delta")
+assert s.server_action_output_format == "absolute"
+assert len(s.norm_stat["q01"]) == 20 and len(s.norm_stat["q99"]) == 20
+if _POOL.is_dir():
+    assert s.obs_cam_keys and s.tactile_keys, \
+        f"no camera/tactile video keys found in {_repo_meta}/info.json"
+    # the selected stats must be the task's own, never the pool envelope
+    _pool_file = _POOL / f"{_NORM_NAME}.json"
+    if _pool_file.is_file():
+        _env = json.loads(_pool_file.read_text())
+        assert s.norm_stat["q01"] != _env["q01"] or s.norm_stat["q99"] != _env["q99"] \
+            or len(_per) == 1, \
+            "per-task norm equals the pool envelope — wrong stats wired"
+
+twam_multitask_server_cfg = s

--- a/n0_twam/configs/twam_posttrain_cfg.py
+++ b/n0_twam/configs/twam_posttrain_cfg.py
@@ -4,7 +4,7 @@
 Fine-tunes the released N0-TWAM checkpoint on ONE task pool: MoT narrow experts,
 LocalTactile ON in "current" mode (flip-on over the local-off release ckpt),
 horizon 12 x 12 actions/frame. _ACTION_MODE selects "absee" (absolute EE,
-default) or "pi05_delta"; each mode has its own norm file and they must never
+default) or "delta" (delta EE); each mode has its own norm file and they must never
 overwrite each other. All tactile-emptying drop probs stay 0 (the MoT tactile
 expert cannot take an empty token sequence).
 
@@ -38,7 +38,7 @@ _TACTILE_KEYS = ["observation.images.tactile_a", "observation.images.tactile_b"]
 _USED_ACTION_CHANNELS = list(range(10))               # single-arm half of the 20-dim schema
 
 # Action representation: "absee" (absolute EE, the final validated recipe) or
-# "pi05_delta" (horizon-delta). Selects action_delta_mode AND the norm file.
+# "delta" (delta EE, horizon-delta). Selects action_delta_mode AND the norm file.
 _ACTION_MODE = "absee"
 
 # ───────── ablation switches (default = FULL model) ─────────
@@ -48,7 +48,7 @@ _USE_LOCAL_TACTILE = True
 _TACTILE_GLOBAL_ZERO = False
 # ───────── end EDIT ME ─────────
 
-assert _ACTION_MODE in ("absee", "pi05_delta"), _ACTION_MODE
+assert _ACTION_MODE in ("absee", "delta"), _ACTION_MODE
 
 cfg = EasyDict(twam_base_cfg.copy())
 cfg.__name__ = f"Config: N0-TWAM post-train ({_ACTION_MODE}, MoT)"

--- a/n0_twam/configs/twam_posttrain_server_cfg.py
+++ b/n0_twam/configs/twam_posttrain_server_cfg.py
@@ -44,7 +44,7 @@ s.enable_offload = False
 s.deterministic_episode_seed = True
 s.cold_seed_mode = "free"
 
-# optional chunk-boundary ramp (pi05_delta only); measured neutral on success.
+# optional chunk-boundary ramp (delta mode only); measured neutral on success.
 s.delta_smooth = False
 s.delta_smooth_k = 3
 

--- a/n0_twam/n0_twam_server.py
+++ b/n0_twam/n0_twam_server.py
@@ -122,9 +122,17 @@ class TWAM_Server:
 
     def _check_train_serve_consistency(self):
         """Refuse placeholder norm stats, and cross-check the checkpoint's
-        train_meta.json (when present) against the live serve config."""
+        train_meta.json (when present) against the live serve config.
+
+        Multi-task checkpoints (``serve_task`` set, see multitask_server): the
+        snapshot's norm_stat is the pool-level fallback envelope no task
+        actually trained with, so the live norm is checked against the pool's
+        per-task table instead, and ``used_action_channel_ids`` — the training
+        union vs the served task's subset — is checked for containment."""
         import json
         from pathlib import Path
+
+        serve_task = getattr(self.job_config, 'serve_task', None)
 
         ns = getattr(self.job_config, 'norm_stat', None) or {}
         q01 = [float(v) for v in ns.get('q01', [])]
@@ -136,20 +144,47 @@ class TWAM_Server:
                 f'(norm_stat_path={getattr(self.job_config, "norm_stat_path", None)!r}). '
                 'Compute the norm stats and point the config at them before serving.')
 
+        problems = []
+        if serve_task:
+            # per-task norm source of truth: the pool table, not the snapshot.
+            per_path = Path(getattr(self.job_config, 'multitask_norm_path', ''))
+            if not per_path.is_file():
+                raise RuntimeError(
+                    f'[consistency] serve_task={serve_task!r} but the per-task '
+                    f'norm table is missing: {per_path}')
+            per = json.loads(per_path.read_text()).get(serve_task)
+            if per is None:
+                raise RuntimeError(
+                    f'[consistency] task {serve_task!r} not in {per_path}')
+            for key in ('q01', 'q99'):
+                want = np.asarray(per.get(key, []), dtype=np.float64)
+                live = np.asarray(ns.get(key, []), dtype=np.float64)
+                if want.shape != live.shape or not np.allclose(want, live, atol=1e-6):
+                    problems.append(
+                        f'norm_stat.{key} differs from the per-task table '
+                        f'({per_path.name}[{serve_task}])')
+
         meta_path = (Path(self.job_config.wan22_pretrained_model_name_or_path)
                      / 'transformer').resolve().parent / 'train_meta.json'
         if not meta_path.is_file():
+            if problems:
+                raise RuntimeError(
+                    '[consistency] serve config does not match the per-task '
+                    'norm table:\n  ' + '\n  '.join(problems))
             logger.info('[consistency] no train_meta.json next to the checkpoint '
                         '(%s) — skipping the training-snapshot cross-check', meta_path)
+            if serve_task:
+                logger.info('[consistency] multi-task per-task norm check passed '
+                            '(task=%s)', serve_task)
             return
         meta = json.loads(meta_path.read_text())
-        problems = []
-        meta_ns = meta.get('norm_stat') or {}
-        for key in ('q01', 'q99'):
-            trained = np.asarray(meta_ns.get(key, []), dtype=np.float64)
-            live = np.asarray(ns.get(key, []), dtype=np.float64)
-            if trained.shape != live.shape or not np.allclose(trained, live, atol=1e-6):
-                problems.append(f'norm_stat.{key} differs from training')
+        if not serve_task:
+            meta_ns = meta.get('norm_stat') or {}
+            for key in ('q01', 'q99'):
+                trained = np.asarray(meta_ns.get(key, []), dtype=np.float64)
+                live = np.asarray(ns.get(key, []), dtype=np.float64)
+                if trained.shape != live.shape or not np.allclose(trained, live, atol=1e-6):
+                    problems.append(f'norm_stat.{key} differs from training')
         for key in ('action_norm_method', 'action_delta_mode', 'action_dim',
                     'action_per_frame', 'pi05_action_horizon',
                     'used_action_channel_ids', 'use_local_tactile',
@@ -162,13 +197,23 @@ class TWAM_Server:
             elif isinstance(meta[key], list):
                 live = [int(v) for v in (live or [])]
                 meta[key] = [int(v) for v in meta[key]]
+            if serve_task and key == 'used_action_channel_ids':
+                # training records the union over all tasks; a served task uses
+                # its own subset (e.g. 10 of 20 for a single-arm task).
+                if not set(live) <= set(meta[key]):
+                    problems.append(
+                        f'{key}: serve {live!r} is not a subset of train {meta[key]!r}')
+                continue
             if meta[key] != live:
                 problems.append(f'{key}: train={meta[key]!r} serve={live!r}')
         if problems:
             raise RuntimeError(
                 '[consistency] serve config does not match the training '
                 f'snapshot {meta_path}:\n  ' + '\n  '.join(problems))
-        logger.info('[consistency] train_meta.json cross-check passed (%s)', meta_path)
+        logger.info('[consistency] train_meta.json cross-check passed (%s%s)',
+                    meta_path,
+                    f'; multi-task norm checked per-task ({serve_task})'
+                    if serve_task else '')
 
     def _get_t5_prompt_embeds(
         self,


### PR DESCRIPTION
## What

Serve support for **multi-task checkpoints** — including the four released
post-trained models (`NeoteAI/n0-twam-{univtac,neosim}-{absee,delta}`) — plus
the docs that list them.

A multi-task pool trains every task with its **own** normalization stats
(`<norm>_per_robot.json` from `script/build_task_pool.py`), so the checkpoint
has no single serve norm: de-normalizing with the pool-level file (a
training-only fallback envelope) scales actions wrongly, and `train_meta.json`
stores that same envelope — so the mismatch would even pass the existing
cross-check silently.

- **`twam_multitask_server_cfg`** (registered `multitask_server`): selects one
  task and wires the per-task norm stats, camera/tactile keys, action channels
  and prompt, all read from the pool itself (`per_robot` table +
  `meta/info.json` + `meta/tasks.jsonl`). Every knob is env-overridable
  (`TWAM_SERVE_*`), so several tasks can be served in parallel without editing
  files.
- **Consistency check**: with `serve_task` set, the live norm is verified
  against the pool's per-task table (instead of the envelope snapshot), and the
  served action channels must be a **subset** of the training union — a
  single-arm task (10 ch) served from a mixed single+dual pool (20 ch) now
  passes instead of being refused.
- **Naming**: the user-facing action mode is `absee` / `delta` (delta EE),
  matching `build_task_pool --mode`; the internal serialized value is unchanged
  for checkpoint compatibility.
- **Docs**: README model table (4 released post-trained checkpoints),
  DEPLOY.md "Serving a multi-task checkpoint", POST_TRAINING.md "Released
  post-trained checkpoints".

## Verification

- Config parity: 33 serve-critical fields compared against the internal serving
  setup used for all released-checkpoint evaluations — 4 combinations
  (single/dual-arm × absee/delta), all fields identical (incl. prompt and
  tactile stream mapping).
- Negative tests: unknown task (error lists the available roster), pool missing
  the per-task table, missing pool (import-safe placeholder, refused at
  runtime), legacy mode string rejected.
- End-to-end: `make_serve_bundle` (train_meta adjacent) + `multitask_server`
  serving a single-arm task of the NeoSim-12 checkpoint — startup cross-check
  passes through the new branch (this exact combination is refused by the old
  code), loopback inference returns `(20, 2, 12)` finite actions whose
  de-normalized x lands inside that task's training quantile range.

Reviewer: @shunlinlu
